### PR TITLE
Replaced NeoFetch with FastFetch for NixOS

### DIFF
--- a/data/users/reedclanton.nix
+++ b/data/users/reedclanton.nix
@@ -24,7 +24,7 @@
 			gF = "git fetch --all -ftp";
 			# TODO: Configure color in grep directly.
 			grep = "grep --color=auto";
-			h = "clear;neofetch;pwd;ls -GAp";
+			h = "clear;fastfetch;pwd;ls -GAp";
 			history = "history --show-all --force-colorization|bat";
 			# TODO: Configure color in ip directly.
 			ip = "ip --color=auto";
@@ -40,7 +40,7 @@
 			ignore = [
         " *"
 				"c"
-				"clear;neofetch;pwd;ls -GAp"
+				"clear;fastfetch;pwd;ls -GAp"
 				"eixt"
 				"exec lynx"
 				"exec lynx -accept_all_cookies"

--- a/modules/nixos/applications/tty/packages/fastfetch.nix
+++ b/modules/nixos/applications/tty/packages/fastfetch.nix
@@ -1,0 +1,4 @@
+{ pkgs, ... }: {
+	environment.systemPackages = with pkgs; [ fastfetch ];
+}
+

--- a/modules/nixos/applications/tty/packages/neofetch.nix
+++ b/modules/nixos/applications/tty/packages/neofetch.nix
@@ -1,4 +1,0 @@
-{ pkgs, ... }: {
-	environment.systemPackages = with pkgs; [ neofetch ];
-}
-


### PR DESCRIPTION
NeoFetch not replaced for Home Manager because Home Manager package install of FastFetch is currently broken. Will merge that in another branch when it's fixed.